### PR TITLE
feat(gcp): Google compute engine startup script to mount attached volumes

### DIFF
--- a/gcp/vm/main.tf
+++ b/gcp/vm/main.tf
@@ -21,6 +21,8 @@ resource "google_compute_instance" "no_external" {
 
         //No external IP
     }
+
+    metadata_startup_script = "${var.create_data_volumes ? file("${path.module}/scripts/bootstrap.sh") : ""}"
 }
 
 resource "google_compute_instance" "external_ip" {
@@ -44,6 +46,8 @@ resource "google_compute_instance" "external_ip" {
             nat_ip = "${element(google_compute_address.default.*.address, count.index)}"
         }
     }
+
+    metadata_startup_script = "${var.create_data_volumes ? file("${path.module}/scripts/bootstrap.sh") : ""}"
 }
 
 resource "google_compute_disk" "data_disk" {

--- a/gcp/vm/scripts/bootstrap.sh
+++ b/gcp/vm/scripts/bootstrap.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+sleep 30
+
+set -e
+
+if blkid /dev/sdb;then 
+        exit
+else 
+        mkfs.ext4 -m 0 -F -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb; \
+        mkdir -p /mnt/disks/data
+        mount -o discard,defaults /dev/sdb /mnt/disks/data
+        cp /etc/fstab /etc/fstab.backup
+        echo UUID=`blkid -s UUID -o value /dev/sdb` /mnt/disks/data ext4 discard,defaults,nofail 0 2 | tee -a /etc/fstab
+fi


### PR DESCRIPTION
# Create bootstrap script to mount data volumes

## Description

This pull request contains a bootstrap script to mount data volumes in each instances which was created by terraform. 

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This changes was tested with terraform, running locally with required permissions in google cloud project. Using `terraform plan` and `terraform apply`

- [X] terraform plan
- [X] terraform apply

**Test Configuration**:
* Terraform version: 0.11.13
* Terraform provider.google: 2.5.1

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
